### PR TITLE
feat(settings): load default settings when project installed

### DIFF
--- a/src/main/java/com/canto/firstspirit/config/CantoProjectApp.java
+++ b/src/main/java/com/canto/firstspirit/config/CantoProjectApp.java
@@ -10,12 +10,20 @@ import de.espirit.firstspirit.module.descriptor.ProjectAppDescriptor;
 @ProjectAppComponent(name = "CantoSaasConfiguration", displayName = "Canto Project Configuration", configurable = CantoProjectAppConfiguration.class)
 public class CantoProjectApp implements ProjectApp {
 
+  private ProjectAppDescriptor projectAppDescriptor;
+  private ProjectEnvironment projectEnvironment;
+
   @Override public void init(final ProjectAppDescriptor projectAppDescriptor, final ProjectEnvironment projectEnvironment) {
-    // stub
+    this.projectEnvironment = projectEnvironment;
+    this.projectAppDescriptor = projectAppDescriptor;
   }
 
   @Override public void installed() {
-    // stub
+    // load default settings
+    CantoProjectAppConfiguration appConfig = new CantoProjectAppConfiguration();
+    appConfig.init(projectAppDescriptor.getModuleName(), projectAppDescriptor.getName(), projectEnvironment);
+    appConfig.load();
+    appConfig.store();
   }
 
   @Override public void uninstalling() {
@@ -23,7 +31,7 @@ public class CantoProjectApp implements ProjectApp {
   }
 
   @Override public void updated(final String s) {
-
+    installed();
   }
 
   public static boolean isInstalled(final SpecialistsBroker broker) {

--- a/src/main/java/com/canto/firstspirit/service/CantoSaasServiceImpl.java
+++ b/src/main/java/com/canto/firstspirit/service/CantoSaasServiceImpl.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 public class CantoSaasServiceImpl implements CantoSaasService, Service<CantoSaasService> {
 
   private ServerEnvironment serverEnvironment;
+  private ServiceDescriptor serviceDescriptor;
   public static final String SERVICE_NAME = "CantoSaasService";
 
   private Map<Integer, CantoApi> apiConnectionPool;
@@ -198,10 +199,15 @@ public class CantoSaasServiceImpl implements CantoSaasService, Service<CantoSaas
 
   @Override public void init(final ServiceDescriptor serviceDescriptor, final ServerEnvironment serverEnvironment) {
     this.serverEnvironment = serverEnvironment;
+    this.serviceDescriptor = serviceDescriptor;
   }
 
   @Override public void installed() {
-    // stub
+    // load default settings
+    CantoSaasServiceConfigurable cantoSaasServiceConfigurable = new CantoSaasServiceConfigurable();
+    cantoSaasServiceConfigurable.init(serviceDescriptor.getModuleName(), serviceDescriptor.getName(), serverEnvironment);
+    cantoSaasServiceConfigurable.load();
+    cantoSaasServiceConfigurable.store();
   }
 
   @Override public void uninstalling() {
@@ -209,6 +215,6 @@ public class CantoSaasServiceImpl implements CantoSaasService, Service<CantoSaas
   }
 
   @Override public void updated(final String s) {
-    // stub
+    installed();
   }
 }


### PR DESCRIPTION
Default settings are not loaded automatically. To do this, the configurations must be opened and saved at least once in Server Manager.

With this adjustment, this happens automatically.